### PR TITLE
Helm upgrade flags and podAntiAffinity

### DIFF
--- a/applications/mlflow/charts/mlflow/Chart.yaml
+++ b/applications/mlflow/charts/mlflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mlflow
 description: A Helm chart for MLflow - Open source platform for the machine learning lifecycle.
 type: application
-version: "0.1.3"
+version: "0.2.0"
 appVersion: "2.10.0"
 home: https://github.com/mlflow/mlflow/tree/master/charts/mlflow
 sources:

--- a/applications/mlflow/charts/mlflow/templates/deployment.yaml
+++ b/applications/mlflow/charts/mlflow/templates/deployment.yaml
@@ -245,9 +245,25 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.mlflow.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.mlflow.affinity }}
+        {{- toYaml .Values.mlflow.affinity | nindent 8 }}
+      {{- else if .Values.mlflow.podAntiAffinityTopologyKey }}
+        podAntiAffinity:
+        {{- if eq .Values.mlflow.podAntiAffinityMode "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+        {{- else if eq .Values.mlflow.podAntiAffinityMode "soft"}}
+          preferredDuringSchedulingIgnoredDuringExecution:
+        {{- else }}
+          {{- fail (printf "(%s) is not a valid pod antiAffinity mode" .Values.mlflow.podAntiAffinityMode) }}
+        {{- end }}
+            - topologyKey: "{{ .Values.mlflow.podAntiAffinityTopologyKey }}"
+              labelSelector:
+                matchExpressions:
+                  - key: "app.kubernetes.io/name"
+                    operator: In
+                    values: 
+                    - {{ include "mlflow.name" . }}
       {{- end }}
       {{- with .Values.mlflow.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/applications/mlflow/charts/mlflow/templates/minio-tenant.yaml
+++ b/applications/mlflow/charts/mlflow/templates/minio-tenant.yaml
@@ -31,7 +31,7 @@ spec:
     name: {{ .configuration.name }}
   pools:
     {{- range $name, $poolValues := .pools }}
-    - servers: {{ dig "servers" 4 $poolValues }}
+    - servers: {{ dig "servers" 3 $poolValues }}
       name: {{ $name }}
       volumesPerServer: {{ dig "volumesPerServer" 4 $poolValues }}
       {{- if dig "runtimeClassName" "" $poolValues }}
@@ -64,8 +64,25 @@ spec:
       {{- with (dig "nodeSelector" (dict) $poolValues) }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (dig "affinity" (dict) $poolValues) }}
-      affinity: {{- toYaml . | nindent 8 }}
+      affinity:
+      {{- if $poolValues.affinity }}
+        {{- toYaml $poolValues.affinity | nindent 8 }}
+      {{- else if $poolValues.podAntiAffinityTopologyKey }}
+        podAntiAffinity:
+        {{- if eq $poolValues.podAntiAffinityMode "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+        {{- else if eq $poolValues.podAntiAffinityMode "soft"}}
+          preferredDuringSchedulingIgnoredDuringExecution:
+        {{- else }}
+          {{- fail (printf "(%s) is not a valid pod antiAffinity mode" $poolValues.podAntiAffinityMode) }}
+        {{- end }}
+            - topologyKey: "{{ $poolValues.podAntiAffinityTopologyKey }}"
+              labelSelector:
+                matchExpressions:
+                  - key: "app.kubernetes.io/name"
+                    operator: In
+                    values: 
+                    - {{ include "mlflow.name" . }}
       {{- end }}
       {{- with (dig "resources" (dict) $poolValues) }}
       resources: {{- toYaml . | nindent 8 }}

--- a/applications/mlflow/charts/mlflow/templates/postgres-cluster.yaml
+++ b/applications/mlflow/charts/mlflow/templates/postgres-cluster.yaml
@@ -29,9 +29,25 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{ end }}
-  {{- with .Values.postgres.embedded.affinity }}
   affinity:
-    {{- toYaml . | nindent 4 }}
+  {{- if .Values.postgres.embedded.affinity }}
+    {{- toYaml .Values.postgres.embedded.affinity | nindent 8 }}
+  {{- else if .Values.postgres.embedded.podAntiAffinityTopologyKey }}
+    podAntiAffinity:
+    {{- if eq .Values.postgres.embedded.podAntiAffinityMode "hard" }}
+      requiredDuringSchedulingIgnoredDuringExecution:
+    {{- else if eq .Values.postgres.embedded.podAntiAffinityMode "soft"}}
+      preferredDuringSchedulingIgnoredDuringExecution:
+    {{- else }}
+      {{- fail (printf "(%s) is not a valid pod antiAffinity mode" .Values.postgres.embedded.podAntiAffinityMode) }}
+    {{- end }}
+        - topologyKey: "{{ .Values.postgres.embedded.podAntiAffinityTopologyKey }}"
+          labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values: 
+                - {{ include "mlflow.name" . }}
   {{- end }}
   priorityClassName: {{ .Values.postgres.embedded.priorityClassName }}
   primaryUpdateMethod: {{ .Values.postgres.embedded.primaryUpdateMethod }}

--- a/applications/mlflow/charts/mlflow/values.yaml
+++ b/applications/mlflow/charts/mlflow/values.yaml
@@ -133,6 +133,15 @@ mlflow:
   # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
   affinity: {}
 
+  # -- Enables podAntiAffinity with the specified topology key
+  # .mlflow.affinity takes precedence over this setting
+  podAntiAffinityTopologyKey: ""
+
+  # -- Specifies whether podAntiAffinity should be "required" or simply "preferred"
+  # This determines if requiredDuringSchedulingIgnoredDuringExecution or preferredDuringSchedulingIgnoredDuringExecution is used
+  # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+  podAntiAffinityMode: "soft"
+
   # -- Defines topologySpreadConstraint rules.
   # [[ref]](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
   topologySpreadConstraints: []
@@ -352,7 +361,7 @@ minio:
       # For standalone mode, supply 1. For distributed mode, supply 4 or more.
       # Note that the operator does not support upgrading from standalone to distributed mode.
       pool0:
-        servers: 4
+        servers: 3
         # -- Custom name for the pool
         name: pool-0
         # -- The number of volumes attached per MinIO Tenant Pod / Server.
@@ -369,8 +378,16 @@ minio:
         tolerations: []
         # -- Any `Node Selectors <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/>`__ to apply to Tenant pods.
         nodeSelector: {}
-        # -- The `affinity <https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/>`__ or anti-affinity settings to apply to Tenant pods.
+        # -- Affinity/Anti-affinity rules for Pods.
+        # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration
         affinity: {}
+        # -- Enables podAntiAffinity with the specified topology key
+        # .minio.tenant.pool.pool0.affinity takes precedence over this setting
+        podAntiAffinityTopologyKey: ""
+        # -- Specifies whether podAntiAffinity should be "required" or simply "preferred"
+        # This determines if requiredDuringSchedulingIgnoredDuringExecution or preferredDuringSchedulingIgnoredDuringExecution is used
+        # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+        podAntiAffinityMode: "soft"
         # -- The `Requests or Limits <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`__ for resources to associate to Tenant pods.
         resources: { }
         # -- The Kubernetes `SecurityContext <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>`__ to use for deploying Tenant resources.
@@ -626,8 +643,14 @@ postgres:
     logLevel: "info"
     # -- Affinity/Anti-affinity rules for Pods.
     # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration
-    affinity:
-      topologyKey: topology.kubernetes.io/zone
+    affinity: {}
+    # -- Enables podAntiAffinity with the specified topology key
+    # .postgres.embedded.affinity takes precedence over this setting
+    podAntiAffinityTopologyKey: ""
+    # -- Specifies whether podAntiAffinity should be "required" or simply "preferred"
+    # This determines if requiredDuringSchedulingIgnoredDuringExecution or preferredDuringSchedulingIgnoredDuringExecution is used
+    # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)
+    podAntiAffinityMode: "soft"
     # -- The configuration for the CA and related certificates.
     # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration
     certificates: {}

--- a/applications/mlflow/kots/cloudnative-pg-chart.yaml
+++ b/applications/mlflow/kots/cloudnative-pg-chart.yaml
@@ -8,6 +8,8 @@ spec:
     chartVersion: 0.21.2
   exclude: 'repl{{ or (ConfigOptionEquals `postgres_type` `external_postgres`) (eq Distribution "embedded-cluster") }}'
   weight: 0
+  helmUpgradeFlags:
+    - --wait
   values:
     image:
       repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "ghcr.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "cloudnative-pg" }}/cloudnative-pg'

--- a/applications/mlflow/kots/cloudnative-pg-chart.yaml
+++ b/applications/mlflow/kots/cloudnative-pg-chart.yaml
@@ -10,6 +10,8 @@ spec:
   weight: 0
   helmUpgradeFlags:
     - --wait
+    - --timeout
+    - 600s
   values:
     image:
       repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "ghcr.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "cloudnative-pg" }}/cloudnative-pg'

--- a/applications/mlflow/kots/minio-operator-chart.yaml
+++ b/applications/mlflow/kots/minio-operator-chart.yaml
@@ -15,3 +15,5 @@ spec:
       repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "minio" }}/operator'
   helmUpgradeFlags:
     - --wait
+    - --timeout
+    - 600s

--- a/applications/mlflow/kots/minio-operator-chart.yaml
+++ b/applications/mlflow/kots/minio-operator-chart.yaml
@@ -13,3 +13,5 @@ spec:
       enabled: false
     image:
       repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "minio" }}/operator'
+  helmUpgradeFlags:
+    - --wait

--- a/applications/mlflow/kots/mlflow-chart.yaml
+++ b/applications/mlflow/kots/mlflow-chart.yaml
@@ -9,6 +9,8 @@ spec:
   weight: 1
   helmUpgradeFlags:
     - --wait
+    - --timeout
+    - 600s
   values:
     mlflow:
       image:

--- a/applications/mlflow/kots/mlflow-chart.yaml
+++ b/applications/mlflow/kots/mlflow-chart.yaml
@@ -5,8 +5,10 @@ metadata:
 spec:
   chart:
     name: mlflow
-    chartVersion: 0.1.3
+    chartVersion: 0.2.0
   weight: 1
+  helmUpgradeFlags:
+    - --wait
   values:
     mlflow:
       image:
@@ -26,6 +28,7 @@ spec:
         s3:
           accessKeyId: repl{{ ConfigOption "embedded_s3_access_key" }}
           secretAccessKey: repl{{ ConfigOption "embedded_s3_secret_key" }}
+      podAntiAffinityTopologyKey: "kubernetes.io/hostname"
     postgres:
       auth:
         password: repl{{ ConfigOption "embedded_postgres_password"}}
@@ -33,6 +36,7 @@ spec:
         enabled: repl{{ ConfigOptionEquals "postgres_type" "embedded_postgres" }}
         storage:
           size: repl{{ ConfigOption "embedded_postgres_volume_size"}}
+        podAntiAffinityTopologyKey: "kubernetes.io/hostname"
     minio:
       enabled: repl{{ ConfigOptionEquals "s3_type" "embedded_s3" }}
       secrets:


### PR DESCRIPTION
* Adds support for selecting between `soft` and `hard` podAntiAffinity to force pods not to be scheduled alongside each other for HA purposes
* Adds `--wait` as a helmUpgradeFlag to prevent resource ordering issues between the operator charts and the chart containing CRs