### PR TITLE
fix: add required fields in podAntiAffinity setting

### DIFF
--- a/applications/mlflow/charts/mlflow/Chart.lock
+++ b/applications/mlflow/charts/mlflow/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: replicated
   repository: oci://registry.replicated.com/library
-  version: 1.0.0-beta.25
-digest: sha256:21086dace4404386addebec1abbbcf116493b53588ac8cd80e90595e9861b5fc
-generated: "2024-07-10T12:49:32.523654-04:00"
+  version: 1.0.0-beta.27
+digest: sha256:0063f3ac4e0661d3a547076c4427fc52b837929c33bb47aaf07628969cdc1b42
+generated: "2024-09-12T19:00:34.587369+05:30"

--- a/applications/mlflow/charts/mlflow/templates/deployment.yaml
+++ b/applications/mlflow/charts/mlflow/templates/deployment.yaml
@@ -252,18 +252,27 @@ spec:
         podAntiAffinity:
         {{- if eq .Values.mlflow.podAntiAffinityMode "hard" }}
           requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values: 
+                - {{ include "mlflow.name" . }} 
+            topologyKey: "{{ .Values.mlflow.podAntiAffinityTopologyKey }}"
         {{- else if eq .Values.mlflow.podAntiAffinityMode "soft"}}
           preferredDuringSchedulingIgnoredDuringExecution:
-        {{- else }}
-          {{- fail (printf "(%s) is not a valid pod antiAffinity mode" .Values.mlflow.podAntiAffinityMode) }}
-        {{- end }}
-            - topologyKey: "{{ .Values.mlflow.podAntiAffinityTopologyKey }}"
+          - weight: 100
+            podAffinityTerm:                
+              topologyKey: "{{ .Values.mlflow.podAntiAffinityTopologyKey }}"
               labelSelector:
                 matchExpressions:
                   - key: "app.kubernetes.io/name"
                     operator: In
                     values: 
                     - {{ include "mlflow.name" . }}
+        {{- else }}
+          {{- fail (printf "(%s) is not a valid pod antiAffinity mode" .Values.mlflow.podAntiAffinityMode) }}
+        {{- end }}
       {{- end }}
       {{- with .Values.mlflow.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/applications/mlflow/charts/mlflow/templates/minio-tenant.yaml
+++ b/applications/mlflow/charts/mlflow/templates/minio-tenant.yaml
@@ -71,18 +71,27 @@ spec:
         podAntiAffinity:
         {{- if eq $poolValues.podAntiAffinityMode "hard" }}
           requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: "app.kubernetes.io/name"
+                operator: In
+                values: 
+                - {{ include "mlflow.name" $ }} 
+            topologyKey: "{{ $poolValues.podAntiAffinityTopologyKey }}"
         {{- else if eq $poolValues.podAntiAffinityMode "soft"}}
           preferredDuringSchedulingIgnoredDuringExecution:
-        {{- else }}
-          {{- fail (printf "(%s) is not a valid pod antiAffinity mode" $poolValues.podAntiAffinityMode) }}
-        {{- end }}
-            - topologyKey: "{{ $poolValues.podAntiAffinityTopologyKey }}"
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: "{{ $poolValues.podAntiAffinityTopologyKey }}"
               labelSelector:
                 matchExpressions:
                   - key: "app.kubernetes.io/name"
                     operator: In
                     values: 
-                    - {{ include "mlflow.name" . }}
+                    - {{ include "mlflow.name" $ }}
+        {{- else }}
+          {{- fail (printf "(%s) is not a valid pod antiAffinity mode" $poolValues.podAntiAffinityMode) }}
+        {{- end }}
       {{- end }}
       {{- with (dig "resources" (dict) $poolValues) }}
       resources: {{- toYaml . | nindent 8 }}

--- a/applications/mlflow/charts/mlflow/templates/postgres-cluster.yaml
+++ b/applications/mlflow/charts/mlflow/templates/postgres-cluster.yaml
@@ -36,18 +36,27 @@ spec:
     podAntiAffinity:
     {{- if eq .Values.postgres.embedded.podAntiAffinityMode "hard" }}
       requiredDuringSchedulingIgnoredDuringExecution:
+        labelSelector:
+          matchExpressions:
+          - key: "app.kubernetes.io/name"
+            operator: In
+            values: 
+          - {{ include "mlflow.name" . }} 
+        topologyKey: "{{ .Values.postgres.embedded.podAntiAffinityTopologyKey }}"
     {{- else if eq .Values.postgres.embedded.podAntiAffinityMode "soft"}}
       preferredDuringSchedulingIgnoredDuringExecution:
-    {{- else }}
-      {{- fail (printf "(%s) is not a valid pod antiAffinity mode" .Values.postgres.embedded.podAntiAffinityMode) }}
-    {{- end }}
-        - topologyKey: "{{ .Values.postgres.embedded.podAntiAffinityTopologyKey }}"
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: "{{ .Values.postgres.embedded.podAntiAffinityTopologyKey }}"
           labelSelector:
             matchExpressions:
               - key: "app.kubernetes.io/name"
                 operator: In
                 values: 
                 - {{ include "mlflow.name" . }}
+    {{- else }}
+      {{- fail (printf "(%s) is not a valid pod antiAffinity mode" .Values.postgres.embedded.podAntiAffinityMode) }}
+    {{- end }}
   {{- end }}
   priorityClassName: {{ .Values.postgres.embedded.priorityClassName }}
   primaryUpdateMethod: {{ .Values.postgres.embedded.primaryUpdateMethod }}


### PR DESCRIPTION
Story details: [https://app.shortcut.com/replicated/story/106553/missing-required-fields-in-podantiaffinity-setting](https://app.shortcut.com/replicated/story/106553/missing-required-fields-in-podantiaffinity-setting)

Demo: 

1. When `podAntiAffinityMode: "soft"`

https://github.com/user-attachments/assets/24240e80-e616-4080-8928-6fcea1ac5d40

2. When `podAntiAffinityMode: "hard"`


https://github.com/user-attachments/assets/4e1cd633-cc39-43c8-be36-e29102167ff5

Based on the above pod affinity mode, users can now deploy their application without facing issues as stated in the story.