### PR TITLE
usability improvements for wg-easy

### DIFF
--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -177,7 +177,7 @@ tasks:
         fi
       - echo "All matching clusters deleted and kubeconfig cleaned up!"
 
-  prepare-release:
+  release-prepare:
     desc: Prepare release files by copying replicated YAML files and packaging Helm charts
     silent: false
     cmds:

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -5,7 +5,7 @@ includes:
 
 vars:
   # Application configuration
-  APP_NAME: '{{.APP_NAME | default "wg-easy"}}'
+  APP_NAME: '{{.REPLICATED_APP | default "wg-easy"}}'
   
   # Cluster configuration
   CLUSTER_NAME: '{{.CLUSTER_NAME | default "test-cluster"}}'


### PR DESCRIPTION
- uses consistent naming scheme for release based tasks
   this improves discoverability of tasks through intuition / tab complete

- use `REPLICATED_APP` env var in the task file
   we already have this env var set to work with the replicated cli, we can use it to infer the app name rather than having duplicate env vars