### PR TITLE
Pull application additionalNamespaces from helmChart resources

### DIFF
--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -189,6 +189,10 @@ tasks:
       - echo "Copying non-config YAML files to release folder..."
       - find . -path '*/replicated/*.yaml' -not -name 'config.yaml' -exec cp {} ./release/ \;
       - find ./replicated -name '*.yaml' -not -name 'config.yaml' -exec cp {} ./release/ \; 2>/dev/null || true
+
+      # extract namespaces from helmChart files
+      - yq ea '[.spec.namespace] | unique' */replicated/helmChart-*.yaml | yq '.spec.additionalNamespaces *= load("/dev/stdin") | .spec.additionalNamespaces += "*" ' replicated/application.yaml > release/application.yaml.new
+      - mv release/application.yaml.new release/application.yaml
       
       # Merge config.yaml files
       - echo "Merging config.yaml files..."

--- a/applications/wg-easy/replicated/application.yaml
+++ b/applications/wg-easy/replicated/application.yaml
@@ -9,11 +9,12 @@ spec:
   allowRollback: true
   #additionalImages:
   #  - jenkins/jenkins:lts
-  additionalNamespaces:
-    - "cert-manager"
-    - "traefik"
-    - "wg-easy"
-    - "*"
+  # additionalNamespaces should be populated by the Task file
+  # additionalNamespaces:
+  #   - "cert-manager"
+  #   - "traefik"
+  #   - "wg-easy"
+  #   - "*"
   #ports:
   #  - serviceName: wg-easy/web
   #    servicePort: 51821

--- a/applications/wg-easy/replicated/application.yaml
+++ b/applications/wg-easy/replicated/application.yaml
@@ -9,12 +9,7 @@ spec:
   allowRollback: true
   #additionalImages:
   #  - jenkins/jenkins:lts
-  # additionalNamespaces should be populated by the Task file
-  # additionalNamespaces:
-  #   - "cert-manager"
-  #   - "traefik"
-  #   - "wg-easy"
-  #   - "*"
+  #additionalNamespaces should be populated by the Task file
   #ports:
   #  - serviceName: wg-easy/web
   #    servicePort: 51821


### PR DESCRIPTION
`additionalNamespaces` in the release `Application` manifest should be treated as a generated field, with the source of truth being the collected list of `.spec.namespace` fields from included `helmChart` manifests. 