### PR TITLE
feat: wg-easy add preflights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ applications/wg-easy/release/
 .aider*
 # SpecStory explanation file
 .specstory/.what-is-this.md
-preflightbundle-*.tar.gz
+*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ applications/wg-easy/release/
 .aider*
 # SpecStory explanation file
 .specstory/.what-is-this.md
+preflightbundle-*.tar.gz

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -185,8 +185,7 @@ tasks:
     desc: Run preflight checks on Helm charts using preflight CLI (use DRY_RUN=true for dry-run)
     silent: false
     vars:
-      DRY_RUN:
-        default: false
+      DRY_RUN: '{{.DRY_RUN | default "false"}}'
     cmds: 
       - |
         PREFLIGHT_FLAGS=""

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -181,6 +181,36 @@ tasks:
     deps:
       - cluster-create
 
+  helm-preflight-dryrun:
+    desc: Verify the preflight specs that will be run
+    silent: false
+    cmds: 
+      - |
+        TEMP_FILE=$(mktemp)
+        
+        # Find all charts and append their templates to the temp file
+        for chart_dir in $(find charts/ -maxdepth 1 -mindepth 1 -type d); do
+          helm template "$chart_dir" >> "$TEMP_FILE"
+          echo "---" >> "$TEMP_FILE" # Add separator between charts
+        done
+        
+        # Run preflight once on the combined templates
+        echo "Running preflight checks on all templates"
+        cat "$TEMP_FILE" | kubectl preflight - --dry-run
+        
+        # Clean up
+        rm "$TEMP_FILE"
+
+  helm-preflight:
+    desc: Run preflight checks on Helm charts using preflight CLI
+    silent: false
+    cmds: 
+      - defer: rm -f preflightbundle-*.tar.gz
+      - helm template charts/wg-easy | kubectl preflight -
+      - helm template charts/cert-manager | kubectl preflight -
+    deps:
+      - setup-kubeconfig
+    
   helm-install:
     desc: Install all charts using helmfile
     silent: false
@@ -492,6 +522,7 @@ tasks:
       - task: setup-kubeconfig
       - task: cluster-ports-expose
       - task: dependencies-update
+      - task: helm-preflight
       - task: helm-install
       - task: test
       - task: cluster-delete

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -181,36 +181,25 @@ tasks:
     deps:
       - cluster-create
 
-  helm-preflight-dryrun:
-    desc: Verify the preflight specs that will be run
+  helm-preflight:
+    desc: Run preflight checks on Helm charts using preflight CLI (use DRY_RUN=true for dry-run)
     silent: false
+    vars:
+      DRY_RUN: '{{.DRY_RUN | default "false"}}'
     cmds: 
       - |
-        TEMP_FILE=$(mktemp)
-        
-        # Find all charts and append their templates to the temp file
-        for chart_dir in $(find charts/ -maxdepth 1 -mindepth 1 -type d); do
-          helm template "$chart_dir" >> "$TEMP_FILE"
-          echo "---" >> "$TEMP_FILE" # Add separator between charts
-        done
-        
-        # Run preflight once on the combined templates
-        echo "Running preflight checks on all templates"
-        cat "$TEMP_FILE" | kubectl preflight - --dry-run
-        
-        # Clean up
-        rm "$TEMP_FILE"
+        PREFLIGHT_FLAGS=""
+        if [ "{{.DRY_RUN}}" = "true" ]; then          
+          PREFLIGHT_FLAGS="--dry-run"
+        fi
 
-  helm-preflight:
-    desc: Run preflight checks on Helm charts using preflight CLI
-    silent: false
-    cmds: 
-      - defer: rm -f preflightbundle-*.tar.gz
-      - helm template charts/wg-easy | kubectl preflight -
-      - helm template charts/cert-manager | kubectl preflight -
+        for chart_dir in $(find charts/ -maxdepth 2 -name "Chart.yaml" | xargs dirname); do
+          echo "Running preflight on $chart_dir"
+          helm template $chart_dir | kubectl preflight - $PREFLIGHT_FLAGS
+        done
     deps:
       - setup-kubeconfig
-    
+
   helm-install:
     desc: Install all charts using helmfile
     silent: false

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -185,7 +185,8 @@ tasks:
     desc: Run preflight checks on Helm charts using preflight CLI (use DRY_RUN=true for dry-run)
     silent: false
     vars:
-      DRY_RUN: '{{.DRY_RUN | default "false"}}'
+      DRY_RUN:
+        default: false
     cmds: 
       - |
         PREFLIGHT_FLAGS=""

--- a/applications/wg-easy/charts/cert-manager/templates/_preflight.tpl
+++ b/applications/wg-easy/charts/cert-manager/templates/_preflight.tpl
@@ -1,0 +1,21 @@
+{{- define "cert-manager.preflight" -}}
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: cert-manager-preflights
+spec:
+  analyzers:
+    # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#prerequisites
+    - clusterVersion:
+        outcomes:
+          - fail:
+              when: "< 1.22.0"
+              message: The application requires at least Kubernetes 1.22.0, and recommends 1.25.0.
+              uri: https://cert-manager.io/docs/installation/helm/#prerequisites
+          - warn:
+              when: "< 1.25.0"
+              message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.25.0 or later.
+              uri: https://cert-manager.io/docs/installation/helm/#prerequisites
+          - pass:
+              message: Your cluster meets the recommended and required versions of Kubernetes.
+{{- end -}} 

--- a/applications/wg-easy/charts/cert-manager/templates/secret-preflights.yaml
+++ b/applications/wg-easy/charts/cert-manager/templates/secret-preflights.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-manager-preflights
+  labels:
+    troubleshoot.sh/kind: preflight
+type: Opaque
+stringData:
+  preflight.yaml: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Preflight
+    metadata:
+      name: cert-manager-preflights
+    spec:
+      analyzers:
+        # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#prerequisites
+        - clusterVersion:
+            outcomes:
+              - fail:
+                  when: "< 1.22.0"
+                  message: The application requires at least Kubernetes 1.22.0, and recommends 1.25.0.
+                  uri: https://kubernetes.io
+              - warn:
+                  when: "< 1.25.0"
+                  message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.25.0 or later.
+                  uri: https://kubernetes.io
+              - pass:
+                  message: Your cluster meets the recommended and required versions of Kubernetes.

--- a/applications/wg-easy/charts/cert-manager/templates/secret-preflights.yaml
+++ b/applications/wg-easy/charts/cert-manager/templates/secret-preflights.yaml
@@ -7,22 +7,4 @@ metadata:
 type: Opaque
 stringData:
   preflight.yaml: |
-    apiVersion: troubleshoot.sh/v1beta2
-    kind: Preflight
-    metadata:
-      name: cert-manager-preflights
-    spec:
-      analyzers:
-        # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/README.template.md#prerequisites
-        - clusterVersion:
-            outcomes:
-              - fail:
-                  when: "< 1.22.0"
-                  message: The application requires at least Kubernetes 1.22.0, and recommends 1.25.0.
-                  uri: https://cert-manager.io/docs/installation/helm/#prerequisites
-              - warn:
-                  when: "< 1.25.0"
-                  message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.25.0 or later.
-                  uri: https://cert-manager.io/docs/installation/helm/#prerequisites
-              - pass:
-                  message: Your cluster meets the recommended and required versions of Kubernetes.
+{{ include "cert-manager.preflight" . | indent 4 }}

--- a/applications/wg-easy/charts/cert-manager/templates/secret-preflights.yaml
+++ b/applications/wg-easy/charts/cert-manager/templates/secret-preflights.yaml
@@ -19,10 +19,10 @@ stringData:
               - fail:
                   when: "< 1.22.0"
                   message: The application requires at least Kubernetes 1.22.0, and recommends 1.25.0.
-                  uri: https://kubernetes.io
+                  uri: https://cert-manager.io/docs/installation/helm/#prerequisites
               - warn:
                   when: "< 1.25.0"
                   message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.25.0 or later.
-                  uri: https://kubernetes.io
+                  uri: https://cert-manager.io/docs/installation/helm/#prerequisites
               - pass:
                   message: Your cluster meets the recommended and required versions of Kubernetes.

--- a/applications/wg-easy/charts/wg-easy/templates/_preflight.tpl
+++ b/applications/wg-easy/charts/wg-easy/templates/_preflight.tpl
@@ -1,0 +1,20 @@
+{{- define "wg-easy.preflight" -}}
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: wg-easy-preflights
+spec:
+  collectors:
+    - sysctl:
+        image: debian:buster-slim
+  analyzers:
+    - sysctl:
+        checkName: IP forwarding enabled
+        outcomes:
+          - fail:
+              when: 'net.ipv4.ip_forward == 0'
+              message: "IP forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.ip_forward=1', and run 'sudo sysctl -p'."
+          - pass:
+              when: 'net.ipv4.ip_forward == 1'
+              message: "IP forwarding is enabled."
+{{- end -}} 

--- a/applications/wg-easy/charts/wg-easy/templates/secret-preflights.yaml
+++ b/applications/wg-easy/charts/wg-easy/templates/secret-preflights.yaml
@@ -7,21 +7,4 @@ metadata:
 type: Opaque
 stringData:
   preflight.yaml: |
-    apiVersion: troubleshoot.sh/v1beta2
-    kind: Preflight
-    metadata:
-      name: wg-easy-preflights
-    spec:
-      collectors:
-        - sysctl:
-            image: debian:buster-slim
-      analyzers:
-        - sysctl:
-            checkName: IP forwarding enabled
-            outcomes:
-              - fail:
-                  when: 'net.ipv4.ip_forward == 0'
-                  message: "IP forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.ip_forward=1', and run 'sudo sysctl -p'."
-              - pass:
-                  when: 'net.ipv4.ip_forward == 1'
-                  message: "IP forwarding is enabled."
+{{ include "wg-easy.preflight" . | indent 4 }} 

--- a/applications/wg-easy/charts/wg-easy/templates/secret-preflights.yaml
+++ b/applications/wg-easy/charts/wg-easy/templates/secret-preflights.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wg-easy-preflights
+  labels:
+    troubleshoot.sh/kind: preflight
+type: Opaque
+stringData:
+  preflight.yaml: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Preflight
+    metadata:
+      name: wg-easy-preflights
+    spec:
+      collectors:
+        - sysctl:
+            image: debian:buster-slim
+      analyzers:
+        - sysctl:
+            checkName: IP forwarding enabled
+            outcomes:
+              - fail:
+                  when: 'net.ipv4.ip_forward == 0'
+                  message: "IP forwarding must be enabled. To enable it, edit /etc/sysctl.conf, add or uncomment the line 'net.ipv4.ip_forward=1', and run 'sudo sysctl -p'."
+              - pass:
+                  when: 'net.ipv4.ip_forward == 1'
+                  message: "IP forwarding is enabled."

--- a/applications/wg-easy/docs/development-workflow.md
+++ b/applications/wg-easy/docs/development-workflow.md
@@ -135,19 +135,27 @@ Deploy individual charts to a test cluster to verify functionality.
    task setup-kubeconfig
    ```
 
-2. Install a single chart:
+2. Run preflight checks on your chart:
+
+   ```bash
+   task helm-preflight
+   # Or for a single chart with dry-run:
+   helm template ./charts/wg-easy | kubectl preflight - --dry-run
+   ```
+
+3. Install a single chart:
 
    ```bash
    helm install cert-manager ./charts/cert-manager -n cert-manager --create-namespace
    ```
 
-3. Verify the deployment:
+4. Verify the deployment:
 
    ```bash
    kubectl get pods -n cert-manager
    ```
 
-4. Test chart functionality:
+5. Test chart functionality:
 
    ```bash
    # Example: Test cert-manager with a test certificate
@@ -155,13 +163,13 @@ Deploy individual charts to a test cluster to verify functionality.
    kubectl get certificate -A
    ```
 
-5. Uninstall when done or making changes and repeat step 2:
+6. Uninstall when done or making changes and repeat step 3:
 
    ```bash
    helm uninstall cert-manager -n cert-manager
    ```
 
-**Validation point**: Chart should deploy successfully and function as expected.
+**Validation point**: Preflight checks should pass without errors, and the chart should deploy successfully and function as expected.
 
 ### Stage 5: Integration Testing with helmfile
 

--- a/applications/wg-easy/docs/task-reference.md
+++ b/applications/wg-easy/docs/task-reference.md
@@ -9,7 +9,8 @@ These tasks support the iterative development process, focusing on fast feedback
 | Task | Description | Related Workflow Stage |
 |------|-------------|------------------------|
 | `dependencies-update` | Updates Helm dependencies for all charts in the repository | Stage 1: Dependencies |
-| `helm-deploy` | Deploys all charts using helmfile with proper sequencing | Stage 5: Integration Testing |
+| `helm-preflight` | Runs preflight checks on Helm charts using the preflight CLI | Stage 4: Validation |
+| `helm-install` | Installs all charts using helmfile with proper sequencing | Stage 5: Integration Testing |
 | `ports-expose` | Exposes the configured ports on the cluster for testing | Stage 4-5: Chart Installation/Integration |
 | `remove-k3s-traefik` | Removes pre-installed Traefik from k3s clusters to avoid conflicts | Stage 4-5: Chart Installation/Integration |
 
@@ -17,7 +18,7 @@ These tasks support the iterative development process, focusing on fast feedback
 
 **Complete Update and Deploy:**
 ```bash
-task update-dependencies && task deploy-helm
+task update-dependencies && task helm-install
 ```
 
 **Single Chart Testing:**
@@ -94,9 +95,9 @@ This task performs the following sequence:
 1. Creates a cluster
 2. Sets up the kubeconfig
 3. Exposes ports
-4. Removes pre-installed Traefik
-5. Updates dependencies
-6. Deploys all charts
+4. Updates dependencies
+5. Runs preflight checks on charts
+6. Installs all charts
 7. Runs tests
 8. Deletes the cluster
 
@@ -109,6 +110,7 @@ Many tasks accept parameters to customize their behavior. Here are the most comm
 | `CLUSTER_NAME` | `cluster-create`, `setup-kubeconfig` | Name for the cluster | "test-cluster" |
 | `K8S_VERSION` | `cluster-create` | Kubernetes version | "1.32.2" |
 | `DISTRIBUTION` | `cluster-create` | Cluster distribution | "k3s" |
+| `DRY_RUN` | `helm-preflight` | Run preflight checks in dry-run mode | "false" |
 | `CHANNEL` | `release-create` | Channel to promote to | "Unstable" |
 | `RELEASE_NOTES` | `release-create` | Notes for the release | "" |
 | `GCP_PROJECT` | `gcp-vm-create` | GCP project ID | Required |
@@ -121,7 +123,7 @@ Parameters in the Taskfile.yaml try to always have defaults so that it works out
 These tasks are designed to support the progressive complexity approach:
 
 1. **Early Stages** - Use `dependencies-update` and helm commands directly
-2. **Middle Stages** - Use `cluster-create`, `helm-deploy`,  and `test`
+2. **Middle Stages** - Use `cluster-create`, `helm-install`,  and `test`
 3. **Later Stages** - Use `release-prepare`, `release-create`, and embedded cluster tasks
 
 This organization allows developers to focus on the appropriate level of complexity at each stage of development.


### PR DESCRIPTION
# Add Preflight Checks to WireGuard Easy (wg-easy)

## Overview
This PR adds preflight checks to the `wg-easy` chart.

## Implementation Details
- Each chart-specific preflight is defined as a Kubernetes Secret with label `troubleshoot.sh/kind: preflight`
- Preflight specs are stored in each chart's templates directory:

  ```bash
  cert-manager/templates/secret-preflights.yaml
  wg-easy/templates/secret-preflights.yaml
  ```
- Added new task `helm-preflight` to streamline verification
- Updated container image to include the `preflight` binary

## Current Status
- The PR is based on https://github.com/replicatedhq/platform-examples/pull/55 and will be rebased once that PR is merged
- The `cert-manager` preflight is currently a placeholder to demonstrate multiple preflight specs merging, not the final preflight content
- The `wg-easy` preflight has been implemented with actual checks relevant to the chart

## Testing
Locally verify preflight specs with:

```bash
helm template <chart-dir> | preflight - --dry-run
```

## Next Steps
- [ ] Finalize cert-manager preflights with actual checks
- [ ] Consider adding preflights to additional charts


