### PR TITLE
feat: add wg-easy installation on CMX VM

### DIFF
--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -532,7 +532,7 @@ tasks:
   cmx-vm-create:
     desc: Create a CMX VM instance using Replicated CLI
     run: once
-    silent: false
+    silent: true
     status:
       - |
         # Check if VM is running
@@ -558,7 +558,7 @@ tasks:
 
   cmx-vm-delete:
     desc: Delete a CMX VM instance
-    silent: false
+    silent: true
     cmds:
       - |
         echo "Deleting CMX VM {{.CMX_VM_NAME}}..."
@@ -566,7 +566,7 @@ tasks:
 
   cmx-vm-install:
     desc: Download and install the app as Embedded Cluster on CMX VM
-    silent: false
+    silent: true
     requires:
       vars: [REPLICATED_LICENSE_ID]
     vars:

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -50,7 +50,7 @@ vars:
   CMX_VM_DISK_SIZE: '{{.CMX_VM_DISK_SIZE | default "100"}}'
   CMX_VM_TTL: '{{.CMX_VM_TTL | default "1h"}}'
   CMX_VM_USER: '{{.CMX_VS_USER}}'
-  CMX_VM_PUBLIC_KEY: '{{.CMX_VM_PUBLIC_KEY | default (env "HOME" | printf "%s/.ssh/id_ed25519")}}'
+  CMX_VM_PUBLIC_KEY: '{{.CMX_VM_PUBLIC_KEY}}'
 
 tasks:
   default:
@@ -565,12 +565,13 @@ tasks:
         echo "Deleting CMX VM {{.CMX_VM_NAME}}..."
         replicated vm rm {{.CMX_VM_NAME}}
 
-  cmx-vm-embedded-cluster-setup:
+  cmx-vm-install:
     desc: Download and install the app as Embedded Cluster on CMX VM
     silent: false
     vars:
       CHANNEL: '{{.CHANNEL | default "Unstable"}}'
       AUTH_TOKEN: '{{.AUTH_TOKEN | default "2usDXzovcJNcpn54yS5tFQVNvCq"}}'
+      SKIP_INSTALL: '{{.SKIP_INSTALL | default "false"}}'
       ADMIN_CONSOLE_PASSWORD:
         sh: uuidgen | cut -c1-13
     deps:
@@ -582,21 +583,18 @@ tasks:
       - |
         echo "Check if user is set..."
         if [ -z "{{.CMX_VM_USER}}" ]; then
-          echo "CMX_VM_USER is not set. Set it to your Github handle. E.g. task cmx-vm-embedded-cluster-setup CMX_VM_USER=nvanthao"
-          exit 1
-        fi
-
-        echo "Check if public key exists..."
-        if [ ! -f "{{.CMX_VM_PUBLIC_KEY}}" ]; then
-          echo "{{.CMX_VM_PUBLIC_KEY}} does not exist."
+          echo "CMX_VM_USER is not set. Set it to your Github handle. E.g. task cmx-vm-install CMX_VM_USER=nvanthao"
           exit 1
         fi
 
         echo "SSH into the VM and download the app binary..."
-        SSH_BASE_CMD="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{.CMX_VM_PUBLIC_KEY}}"
-        VM_SSH_CMD=$(replicated vm ls --output=json | jq -r ".[] | select(.name == \"{{.CMX_VM_NAME}}\") | \"$SSH_BASE_CMD -p \(.direct_ssh_port) nvanthao@\(.direct_ssh_endpoint)\"")
+        SSH_BASE_CMD="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+        if [ -n "{{.CMX_VM_PUBLIC_KEY}}" ]; then
+          SSH_BASE_CMD="$SSH_BASE_CMD -i {{.CMX_VM_PUBLIC_KEY}}"
+        fi
+        VM_SSH_CMD=$(replicated vm ls --output=json | jq -r ".[] | select(.name == \"{{.CMX_VM_NAME}}\") | \"$SSH_BASE_CMD -p \(.direct_ssh_port) {{.CMX_VM_USER}}@\(.direct_ssh_endpoint)\"")
  
-        echo "SSH command: $VM_SSH_CMD"
+        echo "SSH base command: $SSH_BASE_CMD"
         $VM_SSH_CMD << 'EOF'
         set -e
         echo 'Downloading {{.APP_NAME}} installer...'
@@ -605,13 +603,18 @@ tasks:
         echo 'Extracting installer...'
         tar -xvzf {{.APP_NAME}}-{{.CHANNEL}}.tgz
 
-        echo "Installing {{.APP_NAME}}..."
-        sudo ./{{.APP_NAME}} install --license license.yaml --admin-console-password {{.ADMIN_CONSOLE_PASSWORD}} --yes
-
+        if [ "{{.SKIP_INSTALL}}" = "false" ]; then
+          echo "Installing {{.APP_NAME}}..."
+          sudo ./{{.APP_NAME}} install --license license.yaml --admin-console-password {{.ADMIN_CONSOLE_PASSWORD}} --yes
+        else
+          echo "Skipping installation as requested. Binary is available at ./{{.APP_NAME}}"
+        fi
         EOF
 
-        echo "Exposing port 30000 on the VM..."
-        replicated vm port expose --port 30000 {{.CMX_VM_NAME}}
+        if [ "{{.SKIP_INSTALL}}" = "false" ]; then
+          echo "Exposing port 30000 on the VM..."
+          replicated vm port expose --port 30000 {{.CMX_VM_NAME}}
 
-        echo "Visit above URL to access the Admin Console, password: {{.ADMIN_CONSOLE_PASSWORD}}"
+          echo "Visit above URL to access the Admin Console, password: {{.ADMIN_CONSOLE_PASSWORD}}"
+        fi
     

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -42,6 +42,16 @@ vars:
   DEV_CONTAINER_NAME: '{{.DEV_CONTAINER_NAME | default "wg-easy-tools"}}'
   CONTAINER_RUNTIME: '{{.CONTAINER_RUNTIME | default "podman"}}'
 
+  # CMX VM configuration
+  CMX_VM_NAME: '{{.CMX_VM_NAME | default (printf "%s-cmx-vm" (or (env "USER") "dev"))}}'
+  CMX_VM_DISTRIBUTION: '{{.CMX_VM_DISTRIBUTION | default "ubuntu"}}'
+  CMX_VM_VERSION: '{{.CMX_VM_VERSION | default "24.04"}}'
+  CMX_VM_INSTANCE_TYPE: '{{.CMX_VM_INSTANCE_TYPE | default "r1.medium"}}'
+  CMX_VM_DISK_SIZE: '{{.CMX_VM_DISK_SIZE | default "100"}}'
+  CMX_VM_TTL: '{{.CMX_VM_TTL | default "1h"}}'
+  CMX_VM_USER: '{{.CMX_VS_USER}}'
+  CMX_VM_PUBLIC_KEY: '{{.CMX_VM_PUBLIC_KEY | default (env "HOME" | printf "%s/.ssh/id_ed25519")}}'
+
 tasks:
   default:
     desc: Show available tasks
@@ -519,3 +529,86 @@ tasks:
       - task: helm-install
       - task: test
       - task: cluster-delete
+
+  cmx-vm-create:
+    desc: Create a CMX VM instance using Replicated CLI
+    run: once
+    silent: false
+    status:
+      - |
+        # Check if VM is running
+        replicated vm ls | grep "{{.CMX_VM_NAME}}" | grep running
+    cmds:
+      - |
+        echo "Creating CMX VM {{.CMX_VM_NAME}}..."
+        replicated vm create --distribution {{.CMX_VM_DISTRIBUTION}} --version {{.CMX_VM_VERSION}} --instance-type {{.CMX_VM_INSTANCE_TYPE}} --disk {{.CMX_VM_DISK_SIZE}} --name {{.CMX_VM_NAME}} --ttl {{.CMX_VM_TTL}}
+
+        echo "Waiting for VM to be running (timeout: 120s)..."
+        for i in $(seq 1 60); do
+          replicated vm ls | grep "{{.CMX_VM_NAME}}"
+          if replicated vm ls | grep "{{.CMX_VM_NAME}}" | grep running; then
+            echo "VM {{.CMX_VM_NAME}} is ready!"
+            break
+          fi
+          if [ $i -eq 60 ]; then
+            echo "Timeout reached after 120s. VM may still be initializing."
+            exit 1
+          fi
+          sleep 2
+        done
+
+  cmx-vm-delete:
+    desc: Delete a CMX VM instance
+    silent: false
+    cmds:
+      - |
+        echo "Deleting CMX VM {{.CMX_VM_NAME}}..."
+        replicated vm rm {{.CMX_VM_NAME}}
+
+  cmx-vm-embedded-cluster-setup:
+    desc: Download and install the app as Embedded Cluster on CMX VM
+    silent: false
+    vars:
+      CHANNEL: '{{.CHANNEL | default "Unstable"}}'
+      AUTH_TOKEN: '{{.AUTH_TOKEN | default "2usDXzovcJNcpn54yS5tFQVNvCq"}}'
+      ADMIN_CONSOLE_PASSWORD:
+        sh: uuidgen | cut -c1-13
+    deps:
+      - cmx-vm-create
+    cmds:
+      - |
+        echo "Check if user is set..."
+        if [ -z "{{.CMX_VM_USER}}" ]; then
+          echo "CMX_VM_USER is not set. Set it to your Github handle. E.g. task cmx-vm-embedded-cluster-setup CMX_VM_USER=nvanthao"
+          exit 1
+        fi
+
+        echo "Check if public key exists..."
+        if [ ! -f "{{.CMX_VM_PUBLIC_KEY}}" ]; then
+          echo "{{.CMX_VM_PUBLIC_KEY}} does not exist."
+          exit 1
+        fi
+
+        echo "SSH into the VM and download the app binary..."
+        SSH_BASE_CMD="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{.CMX_VM_PUBLIC_KEY}}"
+        VM_SSH_CMD=$(replicated vm ls --output=json | jq -r ".[] | select(.name == \"{{.CMX_VM_NAME}}\") | \"$SSH_BASE_CMD -p \(.direct_ssh_port) nvanthao@\(.direct_ssh_endpoint)\"")
+ 
+        echo "SSH command: $VM_SSH_CMD"
+        $VM_SSH_CMD << 'EOF'
+        set -e
+        echo 'Downloading {{.APP_NAME}} installer...'
+        curl -f 'https://replicated.app/embedded/{{.APP_NAME}}/{{.CHANNEL}}' -H 'Authorization: {{.AUTH_TOKEN}}' -o {{.APP_NAME}}-{{.CHANNEL}}.tgz
+        
+        echo 'Extracting installer...'
+        tar -xvzf {{.APP_NAME}}-{{.CHANNEL}}.tgz
+
+        echo "Installing {{.APP_NAME}}..."
+        sudo ./{{.APP_NAME}} install --license license.yaml --admin-console-password {{.ADMIN_CONSOLE_PASSWORD}} --yes
+
+        EOF
+
+        echo "Exposing port 30000 on the VM..."
+        replicated vm port expose --port 30000 {{.CMX_VM_NAME}}
+
+        echo "Visit above URL to access the Admin Console, password: {{.ADMIN_CONSOLE_PASSWORD}}"
+    

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -568,9 +568,10 @@ tasks:
   cmx-vm-install:
     desc: Download and install the app as Embedded Cluster on CMX VM
     silent: false
+    requires:
+      vars: [REPLICATED_LICENSE_ID]
     vars:
       CHANNEL: '{{.CHANNEL | default "Unstable"}}'
-      AUTH_TOKEN: '{{.AUTH_TOKEN | default "2usDXzovcJNcpn54yS5tFQVNvCq"}}'
       SKIP_INSTALL: '{{.SKIP_INSTALL | default "false"}}'
       ADMIN_CONSOLE_PASSWORD:
         sh: uuidgen | cut -c1-13
@@ -587,6 +588,12 @@ tasks:
           exit 1
         fi
 
+        echo "Check if license ID is set..."
+        if [ -z "{{.REPLICATED_LICENSE_ID}}" ]; then
+          echo "REPLICATED_LICENSE_ID is not set. Set it to your DEV Customer License ID. E.g. task cmx-vm-install REPLICATED_LICENSE_ID=1234567890"
+          exit 1
+        fi
+
         echo "SSH into the VM and download the app binary..."
         SSH_BASE_CMD="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
         if [ -n "{{.CMX_VM_PUBLIC_KEY}}" ]; then
@@ -598,7 +605,7 @@ tasks:
         $VM_SSH_CMD << 'EOF'
         set -e
         echo 'Downloading {{.APP_NAME}} installer...'
-        curl -f 'https://replicated.app/embedded/{{.APP_NAME}}/{{.CHANNEL}}' -H 'Authorization: {{.AUTH_TOKEN}}' -o {{.APP_NAME}}-{{.CHANNEL}}.tgz
+        curl -f 'https://replicated.app/embedded/{{.APP_NAME}}/{{.CHANNEL}}' -H 'Authorization: {{.REPLICATED_LICENSE_ID}}' -o {{.APP_NAME}}-{{.CHANNEL}}.tgz
         
         echo 'Extracting installer...'
         tar -xvzf {{.APP_NAME}}-{{.CHANNEL}}.tgz

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -434,7 +434,6 @@ tasks:
     silent: false
     vars:
       CHANNEL: '{{.CHANNEL | default "Unstable"}}'
-      AUTH_TOKEN: '{{.AUTH_TOKEN | default "2usDXzovcJNcpn54yS5tFQVNvCq"}}'
     deps:
       - gcp-vm-create
     status:
@@ -447,7 +446,7 @@ tasks:
           OPERATION: "setup-embedded"
           APP_SLUG: '{{.APP_SLUG}}'
           CHANNEL: '{{.CHANNEL}}'
-          AUTH_TOKEN: '{{.AUTH_TOKEN}}'
+          AUTH_TOKEN: '{{.REPLICATED_LICENSE_ID}}'
           GCP_PROJECT: '{{.GCP_PROJECT}}'
           GCP_ZONE: '{{.GCP_ZONE}}'
           VM_NAME: '{{.VM_NAME}}'

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -575,6 +575,9 @@ tasks:
         sh: uuidgen | cut -c1-13
     deps:
       - cmx-vm-create
+    status:
+      - replicated vm port ls {{.CMX_VM_NAME}}
+      - curl -sL $(replicated vm port ls {{.CMX_VM_NAME}} --output=json | jq -r ".[0].hostname")/healthz
     cmds:
       - |
         echo "Check if user is set..."

--- a/applications/wg-easy/docs/task-reference.md
+++ b/applications/wg-easy/docs/task-reference.md
@@ -45,6 +45,9 @@ These tasks help manage the development and testing environments.
 | `gcp-vm-create` | Creates a GCP VM instance for embedded cluster testing | Stage 7: Embedded Testing |
 | `gcp-vm-delete` | Deletes the GCP VM instance after testing | Stage 7: Cleanup |
 | `embedded-cluster-setup` | Sets up a Replicated embedded cluster on the GCP VM | Stage 7: Embedded Testing |
+| `cmx-vm-create` | Creates a CMX VM instance using Replicated CLI | Stage 7: Embedded Testing |
+| `cmx-vm-delete` | Deletes a CMX VM instance | Stage 7: Cleanup |
+| `cmx-vm-embedded-cluster-setup` | Sets up a Replicated embedded cluster on the CMX VM | Stage 7: Embedded Testing |
 
 ### Common Environment Combinations
 
@@ -115,6 +118,14 @@ Many tasks accept parameters to customize their behavior. Here are the most comm
 | `RELEASE_NOTES` | `release-create` | Notes for the release | "" |
 | `GCP_PROJECT` | `gcp-vm-create` | GCP project ID | Required |
 | `GCP_ZONE` | `gcp-vm-create` | GCP zone | "us-central1-a" |
+| `CMX_VM_NAME` | `cmx-vm-create`, `cmx-vm-delete`, `cmx-vm-embedded-cluster-setup` | Name for the CMX VM | "{{USER}}-cmx-vm" |
+| `CMX_VM_DISTRIBUTION` | `cmx-vm-create` | VM distribution | "ubuntu" |
+| `CMX_VM_VERSION` | `cmx-vm-create` | VM version | "24.04" |
+| `CMX_VM_INSTANCE_TYPE` | `cmx-vm-create` | VM instance type | "r1.medium" |
+| `CMX_VM_DISK_SIZE` | `cmx-vm-create` | VM disk size in GB | "100" |
+| `CMX_VM_TTL` | `cmx-vm-create` | VM time-to-live | "1h" |
+| `CMX_VM_USER` | `cmx-vm-embedded-cluster-setup` | VM user for SSH access | Required |
+| `CMX_VM_PUBLIC_KEY` | `cmx-vm-embedded-cluster-setup` | Path to SSH public key | "~/.ssh/id_ed25519" |
 
 Parameters in the Taskfile.yaml try to always have defaults so that it works out of the box but allows customization for common values.
 

--- a/applications/wg-easy/docs/task-reference.md
+++ b/applications/wg-easy/docs/task-reference.md
@@ -47,7 +47,7 @@ These tasks help manage the development and testing environments.
 | `embedded-cluster-setup` | Sets up a Replicated embedded cluster on the GCP VM | Stage 7: Embedded Testing |
 | `cmx-vm-create` | Creates a CMX VM instance using Replicated CLI | Stage 7: Embedded Testing |
 | `cmx-vm-delete` | Deletes a CMX VM instance | Stage 7: Cleanup |
-| `cmx-vm-embedded-cluster-setup` | Sets up a Replicated embedded cluster on the CMX VM | Stage 7: Embedded Testing |
+| `cmx-vm-install` | Downloads and optionally installs the app as Embedded Cluster on CMX VM | Stage 7: Embedded Testing |
 
 ### Common Environment Combinations
 
@@ -118,14 +118,15 @@ Many tasks accept parameters to customize their behavior. Here are the most comm
 | `RELEASE_NOTES` | `release-create` | Notes for the release | "" |
 | `GCP_PROJECT` | `gcp-vm-create` | GCP project ID | Required |
 | `GCP_ZONE` | `gcp-vm-create` | GCP zone | "us-central1-a" |
-| `CMX_VM_NAME` | `cmx-vm-create`, `cmx-vm-delete`, `cmx-vm-embedded-cluster-setup` | Name for the CMX VM | "{{USER}}-cmx-vm" |
+| `CMX_VM_NAME` | `cmx-vm-create`, `cmx-vm-delete`, `cmx-vm-install` | Name for the CMX VM | "{{USER}}-cmx-vm" |
 | `CMX_VM_DISTRIBUTION` | `cmx-vm-create` | VM distribution | "ubuntu" |
 | `CMX_VM_VERSION` | `cmx-vm-create` | VM version | "24.04" |
 | `CMX_VM_INSTANCE_TYPE` | `cmx-vm-create` | VM instance type | "r1.medium" |
 | `CMX_VM_DISK_SIZE` | `cmx-vm-create` | VM disk size in GB | "100" |
 | `CMX_VM_TTL` | `cmx-vm-create` | VM time-to-live | "1h" |
-| `CMX_VM_USER` | `cmx-vm-embedded-cluster-setup` | VM user for SSH access | Required |
-| `CMX_VM_PUBLIC_KEY` | `cmx-vm-embedded-cluster-setup` | Path to SSH public key | "~/.ssh/id_ed25519" |
+| `CMX_VM_USER` | `cmx-vm-install` | VM user for SSH access | Required |
+| `CMX_VM_PUBLIC_KEY` | `cmx-vm-install` | Path to SSH public key | "" |
+| `SKIP_INSTALL` | `cmx-vm-install` | Skip the installation step, only download binary | "false" |
 
 Parameters in the Taskfile.yaml try to always have defaults so that it works out of the box but allows customization for common values.
 


### PR DESCRIPTION
# Add CMX VM Support for Embedded Cluster Testing

## Overview
This PR adds support for creating and managing CMX VM through Replicated CLI for wg-easy Embedded Cluster testing. This provides an alternative to GCP VMs for testing embedded cluster deployments.

## Changes
- Added new CMX VM configuration variables to `Taskfile.yaml`:
  - VM name, distribution, version, instance type, disk size, and TTL settings
  - SSH configuration for VM access
- Added three new tasks:
  - `cmx-vm-create`: Creates a CMX VM instance with configurable parameters
  - `cmx-vm-delete`: Cleans up CMX VM instances
  - `cmx-vm-embedded-cluster-setup`: Sets up a Replicated embedded cluster on the CMX VM
- Updated `docs/task-reference.md` with:
  - New task descriptions and usage information
  - Documentation for CMX VM-specific parameters

## Testing
The new tasks have been tested with the following workflow:
1. Create CMX VM using `task cmx-vm-create`
2. Set up embedded cluster using `task cmx-vm-embedded-cluster-setup`
3. Verify cluster deployment
4. Clean up using `task cmx-vm-delete`

## Usage Example
```bash
# Create a CMX VM
task cmx-vm-create

# Set up embedded cluster
task cmx-vm-embedded-cluster-setup CMX_VM_USER=github-handle

# Clean up
task cmx-vm-delete
```

## Required Parameters
- `CMX_VM_USER`: GitHub handle for SSH access
- `CMX_VM_PUBLIC_KEY`: Path to SSH public key (defaults to `~/.ssh/id_ed25519`)

## Optional Parameters
- `CMX_VM_NAME`: Custom VM name (defaults to `{USER}-cmx-vm`)
- `CMX_VM_DISTRIBUTION`: VM distribution (defaults to "ubuntu")
- `CMX_VM_VERSION`: VM version (defaults to "24.04")
- `CMX_VM_INSTANCE_TYPE`: VM instance type (defaults to "r1.medium")
- `CMX_VM_DISK_SIZE`: VM disk size in GB (defaults to "100")
- `CMX_VM_TTL`: VM time-to-live (defaults to "1h")