### PR TITLE
feat: wg-easy scope CLUSTER_NAME with USER

### DIFF
--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -16,12 +16,12 @@ vars:
   REPLICATED_LICENSE_ID: '{{.REPLICATED_LICENSE_ID}}'
 
   # Cluster configuration
-  CLUSTER_NAME: '{{.CLUSTER_NAME | default "test-cluster"}}'
+  CLUSTER_NAME: '{{.CLUSTER_NAME | default (printf "%s-cluster" (or (env "USER") "wg-easy-dev"))}}' 
   K8S_VERSION: '{{.K8S_VERSION | default "1.32.2"}}'
   DISK_SIZE: '{{.DISK_SIZE | default "100"}}'
   INSTANCE_TYPE: '{{.INSTANCE_TYPE | default "r1.small"}}'
   DISTRIBUTION: '{{.DISTRIBUTION | default "k3s"}}'
-  KUBECONFIG_FILE: './{{.CLUSTER_NAME}}.kubeconfig'
+  KUBECONFIG_FILE: './test-cluster.kubeconfig'
 
   # Ports configuration
   EXPOSE_PORTS:


### PR DESCRIPTION
# Update Cluster Naming 

If there are multiple people working on wg-easy project from platform-examples, the test-cluster will be shared by everyone.

## Changes
- Modified default cluster name to use a dynamic format: `{username}-cluster` (falls back to `wg-easy-dev-cluster` if USER env var not set)
- Simplified kubeconfig file path to use a static name `test-cluster.kubeconfig` instead of dynamic cluster name

## Why
- Makes cluster names more unique by incorporating username, reducing potential conflicts
- Simplifies kubeconfig file handling by using a consistent filename
- Improves developer experience by making it easier to identify clusters in shared environments

## Testing
- Verified cluster creation with new naming convention
- Confirmed kubeconfig file is properly generated and accessible