### PR TITLE
bug: fix helmfile parsing error for default env

### DIFF
--- a/applications/wg-easy/helmfile.yaml.gotmpl
+++ b/applications/wg-easy/helmfile.yaml.gotmpl
@@ -9,6 +9,8 @@ helmDefaults:
 environments:
   default:
     values:
+      - username: "test@example.com"
+      - password: '{{env "REPLICATED_LICENSE_ID"}}'
       - chartSources:
           certManager: ./charts/cert-manager
           certManagerIssuers: ./charts/cert-manager-issuers


### PR DESCRIPTION
## What

As of now running `task helm-install` will show

```
in ./helmfile.yaml.gotmpl: error during helmfile.yaml.gotmpl.part.1 parsing: template: stringTemplate:5:25: executing "stringTemplate" at <.Values.username>: map has no entry for key "username"
task: Failed to run task "helm-install": exit status 1
```

This occurs because no username is configured for `default` environment.

## Changes
- Add `username` and `password` to default env

## Before
```yaml
environments:
  default:
    values:
      - chartSources:
          certManager: ./charts/cert-manager
          certManagerIssuers: ./charts/cert-manager-issuers
```

## After
```yaml
environments:
  default:
    values:
      - username: "test@example.com"
      - password: '{{env "REPLICATED_LICENSE_ID"}}'
      - chartSources:
          certManager: ./charts/cert-manager
          certManagerIssuers: ./charts/cert-manager-issuers
```

## Testing
- Run `task helm-install` works

## Impact
This change fixes the template parsing error and ensures that the credentials are properly structured for use in the Helm templates. No changes to the actual functionality are required, only the structure of the configuration.