### PR TITLE
feat: wg-easy airgap install

### DIFF
--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -580,7 +580,7 @@ tasks:
       - |
         echo "Deleting CMX VM {{.CMX_VM_NAME}}..."
         replicated vm rm {{.CMX_VM_NAME}}
-
+      
   cmx-vm-install:
     desc: Download and install the app as Embedded Cluster on CMX VM
     silent: true
@@ -611,52 +611,10 @@ tasks:
           exit 1
         fi
 
-        # Check if airgap build is available when airgap mode is enabled
+        # Run airgap-build task if airgap mode is enabled
         if [ "{{.AIRGAP}}" = "true" ]; then
-          echo "Checking if airgap build is available for lastest release in channel {{.CHANNEL}}..."
-          
-          # Get release list and extract app ID and channel ID
-          RELEASE_DATA=$(replicated release ls -o json)
-          APP_ID=$(echo "$RELEASE_DATA" | jq -r '.[0].appId')
-          CHANNEL_ID=$(echo "$RELEASE_DATA" | jq -r '.[0].activeChannels[] | select(.name == "{{.CHANNEL}}") | .id')
-          
-          if [ -z "$APP_ID" ] || [ "$APP_ID" = "null" ]; then
-            echo "Error: Could not retrieve app ID from releases"
-            exit 1
-          fi
-          
-          if [ -z "$CHANNEL_ID" ] || [ "$CHANNEL_ID" = "null" ]; then
-            echo "Error: Could not find channel ID for channel {{.CHANNEL}}"
-            exit 1
-          fi
-          
-          echo "Found app ID: $APP_ID, channel ID: $CHANNEL_ID"
-          
-          # Get channel releases and check airgap build status
-          CHANNEL_RELEASES=$(replicated api get "v3/app/$APP_ID/channel/$CHANNEL_ID/releases")
-          AIRGAP_BUILD_STATUS=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildStatus // "none"')
-          AIRGAP_BUILD_ERROR=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildError // "none"')
-          AIRGAP_BUNDLE_IMAGES=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBundleImages // "none"')
-          AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].sequence')
-          
-          echo "Airgap build status: $AIRGAP_BUILD_STATUS"
-
-          if [ "$AIRGAP_BUILD_STATUS" = "metadata" ]; then
-            echo "Airgap has not been built yet. Triggering build..."
-            replicated api post "v3/app/$APP_ID/channel/$CHANNEL_ID/release/$AIRGAP_LATEST_SEQUENCE/airgap/build"
-            echo "Airgap build triggered. Run the task again later to check if it's ready."
-            exit 1
-          fi
-          
-          if [ "$AIRGAP_BUILD_STATUS" != "built" ]; then
-            echo "Error: Airgap build is not ready. Status: $AIRGAP_BUILD_STATUS"
-            echo "Airgap build error (if any): $AIRGAP_BUILD_ERROR"
-            echo "Please wait for the airgap build to complete before installing in airgap mode."
-            exit 1
-          fi
-          
-          echo "Airgap build is ready. Proceeding with installation..."
-          echo "Contents of airgap bundle images: $AIRGAP_BUNDLE_IMAGES"
+          echo "Airgap mode enabled, ensuring airgap build is ready..."
+          task airgap-build
         fi
 
         echo "SSH into the VM and download the app binary..."
@@ -706,3 +664,72 @@ tasks:
 
           echo "Visit above URL to access the Admin Console, password: {{.ADMIN_CONSOLE_PASSWORD}}"
         fi
+
+  airgap-build:
+    desc: Check and build airgap bundle for the latest release 
+    silent: true
+    cmds:
+      - |
+        echo "Checking if airgap build is available for latest release in channel {{.RELEASE_CHANNEL}}..."
+        
+        # Get release list and extract app ID and channel ID
+        RELEASE_DATA=$(replicated release ls -o json)
+        APP_ID=$(echo "$RELEASE_DATA" | jq -r '.[0].appId')
+        CHANNEL_ID=$(echo "$RELEASE_DATA" | jq -r '.[0].activeChannels[] | select(.name == "{{.RELEASE_CHANNEL}}") | .id')
+        
+        if [ -z "$APP_ID" ] || [ "$APP_ID" = "null" ]; then
+          echo "Error: Could not retrieve app ID from latest releases"
+          exit 1
+        fi
+        
+        if [ -z "$CHANNEL_ID" ] || [ "$CHANNEL_ID" = "null" ]; then
+          echo "Error: Could not find channel ID for channel {{.RELEASE_CHANNEL}}"
+          exit 1
+        fi
+        
+        echo "Found app ID: $APP_ID, channel ID: $CHANNEL_ID"
+        
+        # Get channel releases and check airgap build status
+        CHANNEL_RELEASES=$(replicated api get "v3/app/$APP_ID/channel/$CHANNEL_ID/releases")
+        AIRGAP_BUILD_STATUS=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildStatus // "none"')
+        AIRGAP_BUILD_ERROR=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildError // "none"')
+        AIRGAP_BUNDLE_IMAGES=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBundleImages // "none"')
+        AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].sequence')
+        
+        echo "Airgap build status: $AIRGAP_BUILD_STATUS"
+
+        if [ "$AIRGAP_BUILD_STATUS" = "built" ]; then
+          echo "Airgap is already buit for sequence $AIRGAP_LATEST_SEQUENCE"
+          echo "Airgap bundle images: $AIRGAP_BUNDLE_IMAGES"
+          exit 0
+        fi
+
+        if [ "$AIRGAP_BUILD_STATUS" = "metadata" ]; then
+          echo "Airgap has not been built yet. Triggering build..."
+          replicated api post "v3/app/$APP_ID/channel/$CHANNEL_ID/release/$AIRGAP_LATEST_SEQUENCE/airgap/build"
+        fi
+
+        echo "Airgap build triggered. Polling every 10 seconds for up to 5 minutes..."
+        for i in $(seq 1 30); do
+          echo "Checking airgap build status... (attempt $i/30)"
+
+          CHANNEL_RELEASES=$(replicated api get "v3/app/$APP_ID/channel/$CHANNEL_ID/releases")
+          AIRGAP_BUILD_STATUS=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildStatus // "none"')
+          AIRGAP_BUILD_ERROR=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildError // "none"')
+          AIRGAP_BUNDLE_IMAGES=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBundleImages // "none"')
+          AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].sequence')
+
+          echo "Airgap build current status: $AIRGAP_BUILD_STATUS"
+
+          if [ "$AIRGAP_BUILD_STATUS" = "built" ]; then
+            echo "Airgap build completed successfully!"
+            echo "Airgap bundle images: $AIRGAP_BUNDLE_IMAGES"
+            exit 0
+          fi
+          sleep 10
+        done
+
+        echo "Timeout: Airgap build did not complete within 5 minutes."
+        echo "Last build status: $AIRGAP_BUILD_STATUS"
+        echo "Last build error: $AIRGAP_BUILD_ERROR"
+        exit 1

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -611,6 +611,46 @@ tasks:
           exit 1
         fi
 
+        # Check if airgap build is available when airgap mode is enabled
+        if [ "{{.AIRGAP}}" = "true" ]; then
+          echo "Checking if airgap build is available for lastest release in channel {{.CHANNEL}}..."
+          
+          # Get release list and extract app ID and channel ID
+          RELEASE_DATA=$(replicated release ls -o json)
+          APP_ID=$(echo "$RELEASE_DATA" | jq -r '.[0].appId')
+          CHANNEL_ID=$(echo "$RELEASE_DATA" | jq -r '.[0].activeChannels[] | select(.name == "{{.CHANNEL}}") | .id')
+          
+          if [ -z "$APP_ID" ] || [ "$APP_ID" = "null" ]; then
+            echo "Error: Could not retrieve app ID from releases"
+            exit 1
+          fi
+          
+          if [ -z "$CHANNEL_ID" ] || [ "$CHANNEL_ID" = "null" ]; then
+            echo "Error: Could not find channel ID for channel {{.CHANNEL}}"
+            exit 1
+          fi
+          
+          echo "Found app ID: $APP_ID, channel ID: $CHANNEL_ID"
+          
+          # Get channel releases and check airgap build status
+          CHANNEL_RELEASES=$(replicated api get "v3/app/$APP_ID/channel/$CHANNEL_ID/releases")
+          AIRGAP_BUILD_STATUS=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildStatus // "none"')
+          AIRGAP_BUILD_ERROR=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildError // "none"')
+          AIRGAP_BUNDLE_IMAGES=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBundleImages // "none"')
+          
+          echo "Airgap build status: $AIRGAP_BUILD_STATUS"
+          
+          if [ "$AIRGAP_BUILD_STATUS" != "built" ]; then
+            echo "Error: Airgap build is not ready. Status: $AIRGAP_BUILD_STATUS"
+            echo "Airgap build error (if any): $AIRGAP_BUILD_ERROR"
+            echo "Please wait for the airgap build to complete before installing in airgap mode."
+            exit 1
+          fi
+          
+          echo "Airgap build is ready. Proceeding with installation..."
+          echo "Contents of airgap bundle images: $AIRGAP_BUNDLE_IMAGES"
+        fi
+
         echo "SSH into the VM and download the app binary..."
         SSH_BASE_CMD="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
         if [ -n "{{.CMX_VM_PUBLIC_KEY}}" ]; then

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -589,6 +589,7 @@ tasks:
     vars:
       CHANNEL: '{{.CHANNEL | default "Unstable"}}'
       SKIP_INSTALL: '{{.SKIP_INSTALL | default "false"}}'
+      AIRGAP: '{{.AIRGAP | default "false"}}'
       ADMIN_CONSOLE_PASSWORD:
         sh: uuidgen | cut -c1-13
     deps:
@@ -617,27 +618,43 @@ tasks:
         fi
         VM_SSH_CMD=$(replicated vm ls --output=json | jq -r ".[] | select(.name == \"{{.CMX_VM_NAME}}\") | \"$SSH_BASE_CMD -p \(.direct_ssh_port) {{.CMX_VM_USER}}@\(.direct_ssh_endpoint)\"")
 
+        # Determine download URL based on airgap setting
+        DOWNLOAD_URL="https://replicated.app/embedded/{{.APP_SLUG}}/{{.CHANNEL}}"
+        if [ "{{.AIRGAP}}" = "true" ]; then
+          DOWNLOAD_URL="${DOWNLOAD_URL}?airgap=true"
+        fi
+
         echo "SSH base command: $SSH_BASE_CMD"
-        $VM_SSH_CMD << 'EOF'
+        $VM_SSH_CMD << EOF
         set -e
-        echo 'Downloading {{.APP_NAME}} installer...'
-        curl -f 'https://replicated.app/embedded/{{.APP_NAME}}/{{.CHANNEL}}' -H 'Authorization: {{.REPLICATED_LICENSE_ID}}' -o {{.APP_NAME}}-{{.CHANNEL}}.tgz
+        echo 'Downloading {{.APP_SLUG}} installer...'
+        curl -f '$DOWNLOAD_URL' -H 'Authorization: {{.REPLICATED_LICENSE_ID}}' -o {{.APP_SLUG}}-{{.CHANNEL}}.tgz
 
         echo 'Extracting installer...'
-        tar -xvzf {{.APP_NAME}}-{{.CHANNEL}}.tgz
-
-        if [ "{{.SKIP_INSTALL}}" = "false" ]; then
-          echo "Installing {{.APP_NAME}}..."
-          sudo ./{{.APP_NAME}} install --license license.yaml --admin-console-password {{.ADMIN_CONSOLE_PASSWORD}} --yes
-        else
-          echo "Skipping installation as requested. Binary is available at ./{{.APP_NAME}}"
-        fi
+        tar -xvzf {{.APP_SLUG}}-{{.CHANNEL}}.tgz
+        
+        echo "Binary is available at ./{{.APP_SLUG}}"
         EOF
 
+        if [ "{{.AIRGAP}}" = "true" ]; then
+          echo "Updating network policy for airgap installation..."
+          NETWORK_ID=$(replicated vm ls --output=json | jq -r ".[] | select(.name == \"{{.CMX_VM_NAME}}\") | .network_id")
+          replicated network update policy $NETWORK_ID --policy airgap
+        fi
+
         if [ "{{.SKIP_INSTALL}}" = "false" ]; then
+          INSTALL_CMD="sudo ./{{.APP_SLUG}} install --license license.yaml --admin-console-password {{.ADMIN_CONSOLE_PASSWORD}} --yes"
+          if [ "{{.AIRGAP}}" = "true" ]; then
+            INSTALL_CMD="${INSTALL_CMD} --airgap-bundle {{.APP_SLUG}}.airgap"
+          fi
+
+          echo "Running installation command: $INSTALL_CMD"
+        $VM_SSH_CMD << EOF
+        $INSTALL_CMD
+        EOF
+
           echo "Exposing port 30000 on the VM..."
           replicated vm port expose --port 30000 {{.CMX_VM_NAME}}
 
           echo "Visit above URL to access the Admin Console, password: {{.ADMIN_CONSOLE_PASSWORD}}"
         fi
-

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -637,8 +637,16 @@ tasks:
           AIRGAP_BUILD_STATUS=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildStatus // "none"')
           AIRGAP_BUILD_ERROR=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildError // "none"')
           AIRGAP_BUNDLE_IMAGES=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBundleImages // "none"')
+          AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].sequence')
           
           echo "Airgap build status: $AIRGAP_BUILD_STATUS"
+
+          if [ "$AIRGAP_BUILD_STATUS" = "metadata" ]; then
+            echo "Airgap has not been built yet. Triggering build..."
+            replicated api post "v3/app/$APP_ID/channel/$CHANNEL_ID/release/$AIRGAP_LATEST_SEQUENCE/airgap/build"
+            echo "Airgap build triggered. Run the task again later to check if it's ready."
+            exit 1
+          fi
           
           if [ "$AIRGAP_BUILD_STATUS" != "built" ]; then
             echo "Error: Airgap build is not ready. Status: $AIRGAP_BUILD_STATUS"

--- a/applications/wg-easy/Taskfile.yaml
+++ b/applications/wg-easy/Taskfile.yaml
@@ -694,7 +694,7 @@ tasks:
         AIRGAP_BUILD_STATUS=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildStatus // "none"')
         AIRGAP_BUILD_ERROR=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildError // "none"')
         AIRGAP_BUNDLE_IMAGES=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBundleImages // "none"')
-        AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].sequence')
+        AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].channelSequence')
         
         echo "Airgap build status: $AIRGAP_BUILD_STATUS"
 
@@ -717,7 +717,7 @@ tasks:
           AIRGAP_BUILD_STATUS=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildStatus // "none"')
           AIRGAP_BUILD_ERROR=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBuildError // "none"')
           AIRGAP_BUNDLE_IMAGES=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].airgapBundleImages // "none"')
-          AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].sequence')
+          AIRGAP_LATEST_SEQUENCE=$(echo "$CHANNEL_RELEASES" | jq -r '.releases[0].channelSequence')
 
           echo "Airgap build current status: $AIRGAP_BUILD_STATUS"
 

--- a/applications/wg-easy/charts/cert-manager/replicated/helmChart-cert-manager.yaml
+++ b/applications/wg-easy/charts/cert-manager/replicated/helmChart-cert-manager.yaml
@@ -8,5 +8,27 @@ spec:
   weight: 0
   helmUpgradeFlags:
     - --wait
+  values:
+    cert-manager:
+      image:
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "jetstack" }}/cert-manager-controller'
+      webhook:
+        image:
+          registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}'
+          repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "jetstack" }}/cert-manager-webhook'
+      cainjector:
+        image:
+          registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}'
+          repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "jetstack" }}/cert-manager-cainjector'
+      acmesolver:
+        image:
+          registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}'
+          repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "jetstack" }}/cert-manager-acmesolver'
+      startupapicheck:
+        image:
+          registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}'
+          repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "jetstack" }}/cert-manager-startupapicheck'
+  
   namespace: cert-manager
   builder: {}

--- a/applications/wg-easy/charts/cert-manager/replicated/helmChart-cert-manager.yaml
+++ b/applications/wg-easy/charts/cert-manager/replicated/helmChart-cert-manager.yaml
@@ -10,6 +10,9 @@ spec:
     - --wait
   values:
     cert-manager:
+      global:
+        imagePullSecrets:
+          - name: '{{repl ImagePullSecretName }}'
       image:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "quay.io" }}'
         repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "jetstack" }}/cert-manager-controller'

--- a/applications/wg-easy/charts/cert-manager/values.yaml
+++ b/applications/wg-easy/charts/cert-manager/values.yaml
@@ -4,6 +4,10 @@ cert-manager:
       # Override the namespace used to store the ConfigMap for leader election
       namespace: "cert-manager"
   installCRDs: true
+  # Controller image configuration
+  image:
+    registry: quay.io
+    repository: jetstack/cert-manager-controller
   extraArgs: 
       - --cluster-resource-namespace=cert-manager
       - --enable-certificate-owner-ref=true
@@ -11,16 +15,34 @@ cert-manager:
     requests:
       cpu: 5m
       memory: 45Mi
+  # Webhook image configuration
   webhook:
+    image:
+      registry: quay.io
+      repository: jetstack/cert-manager-webhook
     resources:
       requests:
         cpu: 5m
         memory: 22Mi
+  # CA Injector image configuration
   cainjector:
+    image:
+      registry: quay.io
+      repository: jetstack/cert-manager-cainjector
     resources:
       requests:
         cpu: 5m
         memory: 101Mi
+  # ACME Solver image configuration
+  acmesolver:
+    image:
+      registry: quay.io
+      repository: jetstack/cert-manager-acmesolver
+  # Startup API Check image configuration
+  startupapicheck:
+    image:
+      registry: quay.io
+      repository: jetstack/cert-manager-startupapicheck
 local:
   letsencrypt:
     production: false

--- a/applications/wg-easy/charts/replicated/replicated/helmChart-replicated.yaml
+++ b/applications/wg-easy/charts/replicated/replicated/helmChart-replicated.yaml
@@ -20,5 +20,7 @@ spec:
       image:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.replicated.com" }}'
         repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "library" }}/replicated-sdk-image'
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
   namespace: replicated
   builder: {}

--- a/applications/wg-easy/charts/replicated/replicated/helmChart-replicated.yaml
+++ b/applications/wg-easy/charts/replicated/replicated/helmChart-replicated.yaml
@@ -15,6 +15,10 @@ spec:
     - --history-max=15
     - --wait
 
-  values: {}
+  values: 
+    replicated:
+      image:
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.replicated.com" }}'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "library" }}/replicated-sdk-image'
   namespace: replicated
   builder: {}

--- a/applications/wg-easy/charts/replicated/values.yaml
+++ b/applications/wg-easy/charts/replicated/values.yaml
@@ -1,3 +1,6 @@
 # Values for replicated-sdk chart
 replicated:
   enabled: true
+  image:
+    registry: registry.replicated.com
+    repository: "library/replicated-sdk-image"

--- a/applications/wg-easy/charts/traefik/replicated/helmChart-traefik.yaml
+++ b/applications/wg-easy/charts/traefik/replicated/helmChart-traefik.yaml
@@ -13,5 +13,8 @@ spec:
       image:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "docker.io" }}'
         repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "library" }}/traefik'
+      deployment:
+        imagePullSecrets:
+          - name: '{{repl ImagePullSecretName }}'
   namespace: traefik
   builder: {}

--- a/applications/wg-easy/charts/traefik/replicated/helmChart-traefik.yaml
+++ b/applications/wg-easy/charts/traefik/replicated/helmChart-traefik.yaml
@@ -12,6 +12,6 @@ spec:
     traefik:
       image:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "docker.io" }}'
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "" }}/traefik'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "library" }}/traefik'
   namespace: traefik
   builder: {}

--- a/applications/wg-easy/charts/traefik/replicated/helmChart-traefik.yaml
+++ b/applications/wg-easy/charts/traefik/replicated/helmChart-traefik.yaml
@@ -8,5 +8,10 @@ spec:
   weight: 2
   helmUpgradeFlags:
     - --wait
+  values:
+    traefik:
+      image:
+        registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "docker.io" }}'
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace "" }}/traefik'
   namespace: traefik
   builder: {}

--- a/applications/wg-easy/charts/traefik/values.yaml
+++ b/applications/wg-easy/charts/traefik/values.yaml
@@ -4,6 +4,9 @@ certs:
   installStaging: false
   dnsNames: []
 traefik:
+  image:
+    registry: docker.io
+    repository: traefik
   service:
     type: NodePort
   ports:

--- a/applications/wg-easy/charts/wg-easy/replicated/helmChart-wg-easy.yaml
+++ b/applications/wg-easy/charts/wg-easy/replicated/helmChart-wg-easy.yaml
@@ -35,5 +35,9 @@ spec:
           wg-container:
             image:
               repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "ghcr.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "wg-easy" }}/wg-easy'
+    preflight:
+      image:
+        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "docker.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "library" }}/debian:bookworm-slim'
+
   namespace: wg-easy
   builder: {}

--- a/applications/wg-easy/charts/wg-easy/replicated/helmChart-wg-easy.yaml
+++ b/applications/wg-easy/charts/wg-easy/replicated/helmChart-wg-easy.yaml
@@ -16,21 +16,24 @@ spec:
     - --wait
 
   values:
-    wg-easy:
-      services:
-        vpn:
-          # TODO: Template for stand alone KOTS install?
-          #type: NodePort
-          ports:
-            udp:
-              nodePort: repl{{ ConfigOption `vpn-port` | ParseInt  }}
-      wireguard:
-        password: repl{{ ConfigOption `password` }}
-        host: repl{{ ConfigOption `domain` }}
-        port: repl{{ ConfigOption `vpn-port` | ParseInt }}
+    service:
+      vpn:
+        ports:
+          udp:
+            port: repl{{ ConfigOption `vpn-port` | ParseInt  }}
+    wireguard:
+      password: repl{{ ConfigOption `password` }}
+      host: repl{{ ConfigOption `domain` }}
+      port: repl{{ ConfigOption `vpn-port` | ParseInt }}
     templates:
       traefikRoutes:
         web-tls:
           hostName: repl{{ ConfigOption `domain` }}
+    controllers:
+      wg-easy:
+        containers:
+          wg-container:
+            image:
+              repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "ghcr.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "wg-easy" }}/wg-easy'
   namespace: wg-easy
   builder: {}

--- a/applications/wg-easy/charts/wg-easy/replicated/helmChart-wg-easy.yaml
+++ b/applications/wg-easy/charts/wg-easy/replicated/helmChart-wg-easy.yaml
@@ -35,6 +35,9 @@ spec:
           wg-container:
             image:
               repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "ghcr.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "wg-easy" }}/wg-easy'
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: '{{repl ImagePullSecretName }}'
     preflight:
       image:
         repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "docker.io" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace "library" }}/debian:bookworm-slim'

--- a/applications/wg-easy/charts/wg-easy/templates/_preflight.tpl
+++ b/applications/wg-easy/charts/wg-easy/templates/_preflight.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   collectors:
     - sysctl:
-        image: debian:buster-slim
+        image: {{ .Values.preflight.image.repository }}
   analyzers:
     - sysctl:
         checkName: IP forwarding enabled

--- a/applications/wg-easy/charts/wg-easy/values.yaml
+++ b/applications/wg-easy/charts/wg-easy/values.yaml
@@ -133,3 +133,6 @@ persistence:
 preflight:
   image:
     repository: "docker.io/library/debian:bookworm-slim"
+
+defaultPodOptions:
+  imagePullSecrets: []

--- a/applications/wg-easy/charts/wg-easy/values.yaml
+++ b/applications/wg-easy/charts/wg-easy/values.yaml
@@ -129,3 +129,7 @@ persistence:
     retain: false
     globalMounts:
       - path: /etc/wireguard
+
+preflight:
+  image:
+    repository: "docker.io/library/debian:bookworm-slim"

--- a/applications/wg-easy/replicated/application.yaml
+++ b/applications/wg-easy/replicated/application.yaml
@@ -8,8 +8,8 @@ spec:
   icon: https://www.logo.wine/a/logo/WireGuard/WireGuard-Icon-Logo.wine.svg
   #releaseNotes: These are our release notes
   allowRollback: true
-  #additionalImages:
-  #  - jenkins/jenkins:lts
+  additionalImages:
+   - debian:buster-slim
   #additionalNamespaces should be populated by the Task file
   #ports:
   #  - serviceName: wg-easy/web


### PR DESCRIPTION
# Add Airgap Installation Support for WG-Easy

## Summary
This PR adds airgap installation support for the WG-Easy application, enabling deployment in air-gapped environments without internet access.

## Key Changes

### 🚀 Airgap Installation Logic
- **New `AIRGAP` parameter** in Taskfile.yaml to enable airgap mode
- **Automatic airgap build detection** - checks if airgap builds are available for the target release channel
- **Airgap build triggering** - automatically triggers airgap builds if not already built
- **Network policy updates** - switches VM network policy to airgap mode during installation
- **Airgap bundle installation** - modifies installer command to use airgap bundles when enabled

### 🏗️ Image Registry Configuration
Updated all Helm charts to support local registry overrides for airgap deployments with Embedded Cluster

- **cert-manager**: All component images (controller, webhook, cainjector, acmesolver, startupapicheck) now support local registry
- **replicated-sdk**: Added local registry support for SDK image
- **traefik**: Configured to use local registry when available
- **wg-easy**: Main application and preflight images support local registry

## Usage
To install in airgap mode:
```bash
task cmx-vm-install CMX_VM_USER=<user> AIRGAP=true REPLICATED_LICENSE_ID=<id>
```

The system will:
1. Verify airgap builds are available (or trigger them if needed)
2. Download the airgap installer bundle
3. Configure network policies for airgap operation
4. Install using local registry images

## Testing
- ✅ Verified EC installs successfully with all image pushed to private registry
- ✅ Verified app deployed from KOTS with all images loaded from private registry

## TODO
- What need to be done for Helm CLI airgap?
