### PR TITLE
chore: update embedded cluster to 2.8.1 with domain configuration

### DIFF
--- a/applications/wg-easy/replicated/cluster.yaml
+++ b/applications/wg-easy/replicated/cluster.yaml
@@ -3,7 +3,7 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 2.7.2+k8s-1.31
+  version: 2.8.1+k8s-1.31
   domains:
     proxyRegistryDomain: proxy.xdrcft.net
     replicatedAppDomain: app.xdrcft.net

--- a/applications/wg-easy/replicated/cluster.yaml
+++ b/applications/wg-easy/replicated/cluster.yaml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/replicatedhq/embedded-cluster/refs/heads/main/operator/schemas/config-embeddedcluster-v1beta1.json
+
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 2.1.3+k8s-1.29
+  version: 2.7.2+k8s-1.31
+  domains:
+    proxyRegistryDomain: proxy.xdrcft.net
+    replicatedAppDomain: app.xdrcft.net
   unsupportedOverrides:
     k0s: |-
-      config: 
+      config:
         spec:
           workerProfiles:
             - name: default


### PR DESCRIPTION
## Summary
- Update Embedded Cluster version from 2.7.2 to 2.8.1 while maintaining k8s-1.31
- Configure EC domains for proxy registry and replicated app

## Changes
- Update EC version to `2.8.1+k8s-1.31` in `replicated/cluster.yaml`
- Maintain existing domain configuration:
  - `proxyRegistryDomain: proxy.xdrcft.net`
  - `replicatedAppDomain: app.xdrcft.net`

## Testing
- [ ] Verify EC installation with new version
- [ ] Confirm domain configuration works as expected
- [ ] Test proxy registry connectivity