### PR TITLE
fix(flagd): move secret check out of job-level if condition

### DIFF
--- a/.github/workflows/flagd-ci.yml
+++ b/.github/workflows/flagd-ci.yml
@@ -55,10 +55,18 @@ jobs:
           fi
           echo "Checksum changed: $CHECKSUM_BEFORE -> $CHECKSUM_AFTER"
 
+  check-secret:
+    runs-on: ubuntu-22.04
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        run: echo "has-token=${{ secrets.REPLICATED_PLATFORM_EXAMPLES_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
   helm-install-test:
     runs-on: ubuntu-22.04
-    needs: [lint-and-template]
-    if: ${{ secrets.REPLICATED_PLATFORM_EXAMPLES_TOKEN != '' }}
+    needs: [lint-and-template, check-secret]
+    if: needs.check-secret.outputs.has-token == 'true'
     defaults:
       run:
         working-directory: applications/flagd


### PR DESCRIPTION
## Summary
- The `secrets` context is not available in job-level `if:` conditions in GitHub Actions, which caused **every** flagd CI run to fail with "This run likely failed because of a workflow file issue"
- Adds a lightweight `check-secret` job that evaluates secret availability and passes the result via outputs
- The `helm-install-test` job now reads from `needs.check-secret.outputs.has-token` instead of referencing `secrets` directly

## Test plan
- [x] Verify the flagd CI workflow passes on this PR (lint-and-template job should succeed, helm-install-test should be skipped if no token)
- [x] Confirm `actionlint` passes locally (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)