### PR TITLE
fix(dependabot): remove all-other-deps group for individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,3 @@ updates:
       replicated-sdk:
         patterns:
           - "replicated"
-      all-other-deps:
-        exclude-patterns:
-          - "replicated"


### PR DESCRIPTION
## Summary
- Removes the `all-other-deps` group from Dependabot config so each non-Replicated dependency gets its own PR instead of being bundled together
- This makes it easier to review and address breaking changes individually (e.g. postgresql 15→17, mlflow v3→v3.11)
- Closed #157 so Dependabot will reopen individual PRs

## Test plan
- [ ] Verify Dependabot opens individual PRs for non-replicated dependencies on next scheduled run
- [ ] Confirm `replicated-sdk` group continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)