### PR TITLE
feat(mlflow): add security hardening defaults and NetworkPolicy

### DIFF
--- a/applications/mlflow/charts/mlflow/templates/deployment.yaml
+++ b/applications/mlflow/charts/mlflow/templates/deployment.yaml
@@ -214,6 +214,8 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         {{- if .Values.mlflow.extraPipPackages }}
         - name: pip-packages
           mountPath: /pip-packages
@@ -260,6 +262,8 @@ spec:
         {{ toYaml . | nindent 6 }}
       {{- end }}
       volumes:
+      - name: tmp
+        emptyDir: {}
       {{- if .Values.mlflow.extraPipPackages }}
       - name: pip-packages
         emptyDir: {}

--- a/applications/mlflow/charts/mlflow/templates/networkpolicy.yaml
+++ b/applications/mlflow/charts/mlflow/templates/networkpolicy.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mlflow.fullname" . }}
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mlflow.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.allowSameNamespace }}
+    # Allow all traffic from pods in the same namespace
+    - from:
+        - podSelector: {}
+    {{- end }}
+    {{- if .Values.networkPolicy.ingress.ingressNginx.enabled }}
+    # Allow ingress-nginx to reach mlflow on the tracking server port
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingress.ingressNginx.namespace }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.mlflow.service.port }}
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.allowSameNamespace }}
+    # Allow all traffic to pods in the same namespace
+    - to:
+        - podSelector: {}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.dns.enabled }}
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: {{ .Values.networkPolicy.egress.dns.port }}
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.dns.port }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.postgres.enabled }}
+    # Allow mlflow to reach postgres
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.postgres.port }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.minio.enabled }}
+    # Allow mlflow to reach minio
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.minio.port }}
+    {{- end }}
+{{- end }}

--- a/applications/mlflow/charts/mlflow/values.yaml
+++ b/applications/mlflow/charts/mlflow/values.yaml
@@ -47,11 +47,22 @@ mlflow:
   # -- Pod Labels for the mlflow deployment
   podLabels: {}
   # -- Configure the Security Context for the Pod
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   # -- Set the resource requests / limits for the container.
   resources: {}
   # -- Configure the Security Context for the Container
-  containerSecurityContext: {}
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   # -- Specify probes for the container
   # [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
   probes:
@@ -357,6 +368,34 @@ gpu:
 replicated:
   # -- Specifies whetherto enable the Replicated SDK
   enabled: true
+
+# -- NetworkPolicy configuration for restricting pod traffic
+networkPolicy:
+  # -- Specifies whether to create a NetworkPolicy resource
+  enabled: false
+  # -- Allow ingress from pods in the same namespace
+  allowSameNamespace: true
+  # -- Ingress rules
+  ingress:
+    # -- Allow ingress-nginx to reach mlflow on the tracking server port
+    ingressNginx:
+      enabled: true
+      # -- Namespace where the ingress controller lives
+      namespace: ingress-nginx
+  # -- Egress rules
+  egress:
+    # -- Allow mlflow to reach postgres on port 5432
+    postgres:
+      enabled: true
+      port: 5432
+    # -- Allow mlflow to reach minio on port 9000
+    minio:
+      enabled: true
+      port: 9000
+    # -- Allow DNS resolution (required for service discovery)
+    dns:
+      enabled: true
+      port: 53
 
 minio:
   enabled: true


### PR DESCRIPTION
## Summary

Adds security context defaults and NetworkPolicy template for vendors in regulated industries (SOC 2, HIPAA). Resolves #169.

## Changes

- **podSecurityContext**: `runAsNonRoot: true`, `runAsUser/runAsGroup: 1000`, `fsGroup: 1000`, `seccompProfile: RuntimeDefault`
- **containerSecurityContext**: `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`
- **deployment.yaml**: Added writable `/tmp` emptyDir volume to prevent `readOnlyRootFilesystem` from blocking MLflow runtime (fixes #175 regression — init containers are unaffected as containerSecurityContext only applies to the main container)
- **networkpolicy.yaml**: New template (disabled by default) with:
  - Default deny all ingress/egress
  - Allow same-namespace traffic
  - Allow ingress-nginx → mlflow on port 5000
  - Allow mlflow → postgres on port 5432
  - Allow mlflow → minio on port 9000
  - Allow DNS resolution (UDP/TCP 53)

## Test plan

- [ ] `helm lint` passes
- [ ] `helm template --set networkPolicy.enabled=true` renders NetworkPolicy correctly
- [ ] Deploy with default values — pods start successfully (not stuck in PodInitializing)
- [ ] Deploy with `networkPolicy.enabled=true` — mlflow can reach postgres and minio
- [ ] Verify init containers (pip install, wait-for-postgresql) work with pod security context